### PR TITLE
Exclude ./vendor when building

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,3 +67,4 @@ permalink:    pretty
 paginate:     4
 sass:
   compressed: true
+exclude: ['vendor']


### PR DESCRIPTION
If you choose to install your gems in vendor/bundle (ex. bundle install --path vendor/bundle), then the build breaks because some of the dependencies have filenames that violate Jekyll's guidelines. This change ignores everything in vendor so the build can be nice and happy :-).
