### PR TITLE
Add table styling

### DIFF
--- a/_sass/_tables.scss
+++ b/_sass/_tables.scss
@@ -8,6 +8,7 @@ table {
   max-width: 100%;
   margin-bottom: 1.5;
   font-size: 1.125rem;
+  table-layout: fixed;
   // Cells
   > thead,
   > tbody,
@@ -19,6 +20,7 @@ table {
         line-height: 1.2;
         vertical-align: top;
         border-top: 1px solid #333;
+        overflow: auto;
       }
     }
   }


### PR DESCRIPTION
- fixed table layout
- scroll overflow in cells

This is in response to Issue https://github.com/hackclub/blog/issues/16.
Table now should split the two columns 50/50.