### PR TITLE
Fix Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
-FROM jekyll/jekyll:pages
-MAINTAINER Zach Latta <zach@hackedu.us>
+FROM ruby:2.3
+MAINTAINER Zach Latta <zach@hackclub.com>
 
-RUN rm -rf /srv/jekyll/
-COPY . /srv/jekyll/
-RUN chown -R jekyll:jekyll /srv/jekyll/
+# Set locale to use UTF-8 (from
+# https://github.com/johnotander/pixyll/issues/193#issuecomment-139865963)
+ENV LC_ALL C.UTF-8
+
+# For the JavaScript runtime
+RUN apt-get update && apt-get -y install nodejs
+
+WORKDIR /usr/src/app/
+
+COPY Gemfile /usr/src/app/
+COPY Gemfile.lock /usr/src/app/
+
+RUN bundle install -j8
+
+COPY . /usr/src/app/
 
 EXPOSE 8080
 CMD ["jekyll", "serve", "-P", "8080", "-H", "0.0.0.0"]


### PR DESCRIPTION
The Jekyll Dockerfile updated and broke our build. This changes our Dockerfile from depending on jekyll:pages to depending on ruby:2.3 and manually installing Jekyll.

This closes #22.